### PR TITLE
fix: cloud resource naming conflict in Terraform

### DIFF
--- a/infra/files/xwiki_gce_monitor_dashboard.json
+++ b/infra/files/xwiki_gce_monitor_dashboard.json
@@ -1,7 +1,7 @@
 {
   "category": "CUSTOM",
   "dashboardFilters": [],
-  "displayName": "Xwiki HSA",
+  "displayName": "Xwiki GCE",
   "labels": {},
   "mosaicLayout": {
     "columns": 12,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -97,7 +97,7 @@ module "filestore" {
 data "google_project" "project" {}
 
 resource "google_service_account" "jgroup" {
-  account_id = "xwiki-jgroup"
+  account_id = "xwiki-jgroup-gce"
   depends_on = [
     module.project_services
   ]
@@ -115,7 +115,7 @@ resource "google_storage_hmac_key" "jgroup" {
 
 resource "google_storage_bucket" "xwiki_jgroup" {
   project       = var.project_id
-  name          = "xwiki-jgroup-${data.google_project.project.number}"
+  name          = "xwiki-jgroup-${data.google_project.project.number}-gce"
   location      = var.region
   force_destroy = true
   depends_on = [

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -15,7 +15,7 @@
  */
 
 resource "google_sql_database_instance" "xwiki" {
-  name             = "xwiki-${var.region}-db"
+  name             = "xwiki-${var.region}-db-gce"
   database_version = "MYSQL_8_0"
   region           = var.region
   settings {
@@ -51,7 +51,7 @@ resource "google_sql_user" "xwiki" {
 }
 
 resource "google_compute_global_address" "sql" {
-  name          = "xwiki-db-address"
+  name          = "xwiki-db-address-gce"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 20

--- a/infra/modules/networking/main.tf
+++ b/infra/modules/networking/main.tf
@@ -16,7 +16,7 @@
 
 resource "google_compute_network" "xwiki" {
   provider                = google
-  name                    = "xwiki"
+  name                    = "xwiki-gce"
   auto_create_subnetworks = true
   project                 = var.project_id
 }


### PR DESCRIPTION
Changed cloud resource names to unique names to allow simultaneous deployment with other JSS within same project.