### PR TITLE
fix: support label injection from metadata

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -88,6 +88,7 @@ module "filestore" {
 
   zone               = local.zones[0]
   private_network_id = module.networking.xwiki_private_network.id
+  labels             = var.labels
 
   depends_on = [
     module.project_services
@@ -117,6 +118,7 @@ resource "google_storage_bucket" "xwiki_jgroup" {
   project       = var.project_id
   name          = "xwiki-jgroup-${data.google_project.project.number}-gce"
   location      = var.region
+  labels        = var.labels
   force_destroy = true
   depends_on = [
     module.project_services
@@ -131,6 +133,7 @@ module "vm" {
   private_network_id = module.networking.xwiki_private_network.id
   xwiki_vm_tag       = local.xwiki_vm_tag
   project_id         = var.project_id
+  labels             = var.labels
   service_account = {
     email = local.vm_sa_email
     scopes = [

--- a/infra/modules/filestore/main.tf
+++ b/infra/modules/filestore/main.tf
@@ -18,6 +18,7 @@ resource "google_filestore_instance" "xwiki" {
   name     = "xwiki-${var.zone}-filestore"
   tier     = "BASIC_HDD"
   location = var.zone
+  labels   = var.labels
   networks {
     network = var.private_network_id
     modes   = ["MODE_IPV4"]

--- a/infra/modules/filestore/variables.tf
+++ b/infra/modules/filestore/variables.tf
@@ -23,3 +23,8 @@ variable "private_network_id" {
   description = "VPC id"
   type        = string
 }
+
+variable "labels" {
+  description = "A map of key/value label pairs to assign to the resources."
+  type        = map(string)
+}

--- a/infra/modules/vm/main.tf
+++ b/infra/modules/vm/main.tf
@@ -33,6 +33,7 @@ module "instance_template" {
     scopes = var.service_account.scopes
   }
   startup_script = var.startup_script
+  labels         = var.labels
 }
 
 module "mig" {

--- a/infra/modules/vm/variables.tf
+++ b/infra/modules/vm/variables.tf
@@ -65,3 +65,8 @@ variable "xwiki_img_info" {
     image_project = string
   })
 }
+
+variable "labels" {
+  description = "A map of key/value label pairs to assign to the resources."
+  type        = map(string)
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -66,3 +66,12 @@ variable "xwiki_img_info" {
     image_name    = "hsa-xwiki-vm-img-latest"
   }
 }
+
+variable "labels" {
+  description = "A map of key/value label pairs to assign to the resources."
+  type        = map(string)
+
+  default = {
+    app = "terraform-example-deploy-java-gce"
+  }
+}


### PR DESCRIPTION
This PR contains the following changes:
- Fixed issue #19 
- Added a key/value label pair to [infra/variables.tf ](https://github.com/andrewyct/terraform-example-deploy-java-multizone/blob/571197cdbf7b431954307b0bb41a491adaa2601b/infra/variables.tf)