### PR TITLE
fix: Use verbose string for Filestore network

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -89,6 +89,7 @@ module "filestore" {
   zone               = local.zones[0]
   private_network_id = module.networking.xwiki_private_network.id
   labels             = var.labels
+  project_id         = var.project_id
 
   depends_on = [
     module.project_services

--- a/infra/modules/filestore/main.tf
+++ b/infra/modules/filestore/main.tf
@@ -20,7 +20,7 @@ resource "google_filestore_instance" "xwiki" {
   location = var.zone
   labels   = var.labels
   networks {
-    network = var.private_network_id
+    network = "projects/${var.project_id}/global/networks/${var.private_network_id}"
     modes   = ["MODE_IPV4"]
   }
   file_shares {

--- a/infra/modules/filestore/variables.tf
+++ b/infra/modules/filestore/variables.tf
@@ -28,3 +28,8 @@ variable "labels" {
   description = "A map of key/value label pairs to assign to the resources."
   type        = map(string)
 }
+
+variable "project_id" {
+  description = "Google Cloud project ID."
+  type        = string
+}


### PR DESCRIPTION
### Background
* When we ran `terraform apply` for a 2nd time, Terraform suggested force-replacing the `google_filestore_instance` resource:
```
  # module.filestore.google_filestore_instance.xwiki must be replaced
+/- resource "google_filestore_instance" "xwiki" {
...
      ~ networks {
...
          ~ network           = "my-network-name" -> "projects/my-project-id/global/networks/my-network-name" # forces replacement
...
    }
```
* This is because the network name is interpreted as "projects/my-project-id/global/networks/my-network-name" (by the 2nd `terraform apply`) instead of what was define by us in the 1st `terraform apply` - just "my-network-name".

### Change summary
* In this change, we set the `network` value to something like "projects/my-project-id/global/networks/my-network-name" (from the get-go).