### PR TITLE
fix: Use ignore_changes for google_filestore_instance

### DIFF
--- a/infra/modules/filestore/main.tf
+++ b/infra/modules/filestore/main.tf
@@ -27,4 +27,8 @@ resource "google_filestore_instance" "xwiki" {
     capacity_gb = 1024
     name        = "xwiki_file_share"
   }
+  lifecycle {
+    // See https://github.com/hashicorp/terraform-provider-google/issues/16548
+    ignore_changes = [networks[0].network]
+  }
 }


### PR DESCRIPTION
### The problem
* When you run a 2nd `terraform apply`, the Terraform attempts to replace (destroy and recreate) the `google_filestore_instance` resource.
```
# module.simple.module.filestore.google_filestore_instance.xwiki must be replaced
resource "google_filestore_instance" "xwiki" {
...
  networks {
...
    network = "xwiki-gce" -> "projec... iki-gce" # forces replacement
```
* This is due to a bug in the `hashicorp/google` provider: https://github.com/hashicorp/terraform-provider-google/issues/16548.

### The solution
* We add the following chunk:
```
 lifecycle {
    ignore_changes = [networks[0].network]
  }
```
* This will make Terraform ignore deltas in the `network` value (between the local Terraform state and the actual/provisioned Filestore instance state). Such deltas would not result in replacement of the Filestore instance.